### PR TITLE
Remove unnecessary quote

### DIFF
--- a/01-data-frames/README.md
+++ b/01-data-frames/README.md
@@ -644,7 +644,7 @@ We can also access individual cells as follows.
 existing_df.Spain['1990']
 ```
 
-````python
+```python
     44
 ```
 


### PR DESCRIPTION
## Context
There is unnecessary quote which breaks the markdown layout

<img width="986" alt="screen shot 2018-09-09 at 5 03 42 pm" src="https://user-images.githubusercontent.com/883629/45263393-e52c3e00-b452-11e8-9541-c46842efc477.png">

## Changes
Remove the quote

<img width="679" alt="screen shot 2018-09-09 at 5 05 37 pm" src="https://user-images.githubusercontent.com/883629/45263383-ad24fb00-b452-11e8-9c43-b7b97159d496.png">
